### PR TITLE
refreshToken

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -10,6 +10,7 @@ import * as bcrypt from 'bcrypt';
 import {JwtService} from '@nestjs/jwt';
 import { randomBytes } from 'crypto';
 import { LoginDto } from './dto/login.dto';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AuthService {
@@ -18,6 +19,7 @@ export class AuthService {
   constructor(
     private prisma: PrismaService,
     private jwtService: JwtService, 
+    private configService: ConfigService,
     ) {}
 
   //register a new user
@@ -69,16 +71,20 @@ export class AuthService {
     const refreshId = randomBytes(16).toString('hex'); 
     const [accessToken, refreshToken] = await Promise.all([
         this.jwtService.signAsync(payload, {expiresIn: '15m'}),
-        this.jwtService.signAsync({...payload, refreshId}, {expiresIn:'7d'}),
+        this.jwtService.signAsync({...payload, refreshId}, {
+            secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+            expiresIn:'7d'
+        }),
     ])  
      
     return { accessToken, refreshToken };
   }
   
   async updateRefreshToken(userId: string, refreshToken: string): Promise<void>{
+    const hash = await bcrypt.hash(refreshToken, this.SALT_ROUNDS);
     await this.prisma.user.update({
         where: { id: userId },
-        data: { refreshToken }
+        data: { refreshToken: hash }
     });
   }
 


### PR DESCRIPTION
 was signed using the same JWT_SECRET as accessToken, but verified using JWT_REFRESH_SECRET. This mismatch caused the 401 error before validate() was even called. Injecting ConfigService to properly sign it.
 backend AuthService.updateRefreshToken was saving the raw

refreshToken
 to the DB, but RefreshTokenStrategy was using bcrypt.compare() to validate it. Since raw token != bcrypt hash, bcrypt.compare() always fails, causing the active user to be logged out on token expiration.

<img width="1440" height="900" alt="Screenshot 2026-03-24 at 21 02 52" src="https://github.com/user-attachments/assets/3b89634b-e2f1-4b1c-beef-54cc110fa855" />
